### PR TITLE
Complete multi-stage Dockerfile and add non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,35 @@
 FROM golang:1.26-alpine AS builder
 
 ENV GOPROXY="https://proxy.golang.org"
-ENV GO111MODULE="on"
-ENV NAT_ENV="production"
-RUN apk add --no-cache git
+ENV CGO_ENABLED=0
 
-WORKDIR /go/src/github.com/icco/numbers
+WORKDIR /app
+
+# Cache dependency downloads separately from source changes.
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
+RUN go build -ldflags="-s -w" -o /numbers .
 
-EXPOSE 8080
+# ── Runtime image ─────────────────────────────────────────────────────────────
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata
+
+ENV NAT_ENV="production"
 ENV PORT=8080
 
-RUN go build -o /go/bin/numbers .
-CMD ["/go/bin/numbers"]
+EXPOSE 8080
+
+WORKDIR /app
+
+# Run as a non-root user.
+RUN adduser -S -u 1001 app
+USER app
+
+COPY --from=builder /numbers /app/numbers
+# book.txt is read at runtime via os.ReadFile("book.txt") (relative path).
+COPY book.txt /app/book.txt
+
+CMD ["/app/numbers"]


### PR DESCRIPTION
## Problem

The `Dockerfile` had an `AS builder` label but **no second `FROM` stage**:

```dockerfile
FROM golang:1.26-alpine AS builder   # ← "AS builder" with no follow-up stage
# ...
RUN go build -o /go/bin/numbers .
CMD ["/go/bin/numbers"]
```

The `AS builder` alias was never used — the final image was still the full `golang:1.26-alpine` base (~300 MB) containing the Go compiler, `git`, and all build toolchain. The process also ran as **root**.

## Fix

Added a proper minimal final stage:

- **Builder stage**: `golang:1.26-alpine` — compiles the binary with dependency caching and symbol stripping
- **Runtime stage**: `alpine:3.21` — minimal image containing only `ca-certificates`, `tzdata`, the compiled binary, and `book.txt`
- `book.txt` is explicitly copied to the runtime image because the application reads it at runtime via `os.ReadFile("book.txt")` (relative path, resolved against `WORKDIR /app`)
- Added a non-root system user (uid 1001)

## Testing

```bash
docker build -t numbers .
docker run --rm -e PORT=8080 -p 8080:8080 numbers
curl http://localhost:8080/      # should return a single character
curl http://localhost:8080/json  # should return JSON
docker run --rm numbers id       # should show uid=1001(app)
```

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile | Mislabeled single-stage build, runs as root | **Fixed (this PR)** |
| `go.mod` | `go 1.24.0` (one minor version behind other repos) | Worth updating in a future run; no known CVEs |
| Source code | Simple HTTP server, reads a static text file | No action needed |
