### PR TITLE
Upgrade runtime base image from alpine:3.21 to alpine:3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN go build -ldflags="-s -w" -o /numbers .
 
 # ── Runtime image ─────────────────────────────────────────────────────────────
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk add --no-cache ca-certificates tzdata
 


### PR DESCRIPTION
## Problem

The final runtime stage used `alpine:3.21`, which was released in November 2024 and has been superseded by `alpine:3.22` (May 2025). Alpine 3.21 is missing security patches included in 3.22.

## Fix

```diff
-FROM alpine:3.21
+FROM alpine:3.22
```

Single-line bump. The non-root user setup and all other hygiene was already correct.

## Testing

```bash
docker build -t numbers-test .
docker run --rm numbers-test id
# uid=1001(app) gid=65533(nogroup) ...
```

## Audit Note

**Reviewed**: Dockerfile, go.mod, station.go  
**Found & fixed**: outdated alpine:3.21 base image  
**Already good**: non-root user (app, UID 1001), multi-stage build  
**Skipped / future run**: `go.mod` declares `go 1.24.0` while most sibling repos are on `1.25`; worth bumping in a follow-up to pick up new toolchain improvements
