### PR TITLE
Fix HTTP server timeouts, add Recoverer middleware, clamp index bounds

### DIFF
--- a/station.go
+++ b/station.go
@@ -25,6 +25,7 @@ func main() {
 
 	r := chi.NewRouter()
 	r.Use(middleware.RealIP)
+	r.Use(middleware.Recoverer)
 	r.Use(logging.Middleware(log.Desugar(), "icco-cloud"))
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
@@ -52,9 +53,18 @@ func main() {
 		w.Write([]byte("hi."))
 	})
 
-	log.Fatal(http.ListenAndServe(":"+port, r))
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
+// Data holds a single character lookup result derived from the current time.
 type Data struct {
 	Character     rune  `json:"character"`
 	SecondsPassed int64 `json:"seconds_passed"`
@@ -67,6 +77,13 @@ func (d *Data) Log() string {
 	return fmt.Sprintf("(%v / %v) * %d = %d: %s (%d)", d.SecondsPassed, d.Seconds, d.Length, d.Lookup, string(d.Character), d.Character)
 }
 
+// GetCharacter returns the character in book.txt that corresponds to the
+// current position within the week.
+//
+// The nanosecond component of now.Nanosecond() means SecondsPassed can
+// exceed Seconds by up to 999_999_999 ns, making the raw Lookup index
+// equal to (or greater than) Length.  The clamp below prevents the
+// resulting index out-of-range panic.
 func GetCharacter() (*Data, error) {
 	dat, err := os.ReadFile("book.txt")
 	if err != nil {
@@ -86,6 +103,14 @@ func GetCharacter() (*Data, error) {
 		(int64(now.Weekday()) * int64(time.Hour*24)))
 
 	d.Lookup = int64((float64(d.SecondsPassed) / float64(d.Seconds)) * float64(d.Length))
+
+	// Clamp: floating-point rounding can make Lookup == Length (or rarely
+	// larger) during the final nanosecond of Saturday night UTC, causing a
+	// panic on the slice access below.
+	if d.Lookup >= d.Length {
+		d.Lookup = d.Length - 1
+	}
+
 	d.Character = rune(text[d.Lookup])
 
 	log.Debugf(d.Log())


### PR DESCRIPTION
## Problems fixed

### 1. No HTTP server timeouts (Medium — availability)

`station.go` calls `http.ListenAndServe` directly, which creates a server with zero timeouts:

```go
// BEFORE
log.Fatal(http.ListenAndServe(":"+port, r))
```

With no `ReadHeaderTimeout` or `ReadTimeout`, a client that sends headers slowly (classic slow-loris pattern) will hold the connection open indefinitely.  Under enough such connections the server runs out of available file descriptors and becomes unavailable to legitimate clients.

**Fix:** replace with an explicit `http.Server` that sets all four timeouts.

```go
// AFTER
srv := &http.Server{
    Addr:              ":" + port,
    Handler:           r,
    ReadHeaderTimeout: 5 * time.Second,
    ReadTimeout:       10 * time.Second,
    WriteTimeout:      10 * time.Second,
    IdleTimeout:       60 * time.Second,
}
log.Fatal(srv.ListenAndServe())
```

### 2. No `Recoverer` middleware (Low — observability)

Without `middleware.Recoverer`, an unhandled panic inside a handler propagates to Go's built-in per-goroutine net/http recovery, which emits a raw stack trace to stderr and closes the connection without writing a response body.  Adding `Recoverer` gives structured log output and a proper `500 Internal Server Error` response.

### 3. Index out-of-range panic in `GetCharacter` (Medium — correctness)

The lookup index is computed as:

```go
d.Lookup = int64((float64(d.SecondsPassed) / float64(d.Seconds)) * float64(d.Length))
d.Character = rune(text[d.Lookup])   // panics if Lookup >= Length
```

`d.SecondsPassed` is constructed by summing nanosecond, second, minute, hour, and weekday components.  The maximum value of the nanosecond sub-component alone (`now.Nanosecond() * time.Nanosecond`) is **999,999,999 ns**, which can push `SecondsPassed` beyond `Seconds` (7 days in nanoseconds), making the floating-point ratio exceed 1.0 and `Lookup` equal to or greater than `Length`.

This would cause `text[d.Lookup]` to panic during roughly the last second of every Saturday night UTC. Go's `net/http` recovers per-goroutine panics, so the process doesn't die, but every request during that window returns a blank 500 response.

**Fix:** clamp `Lookup` to `Length - 1` after the computation.

## Testing steps

1. `go build ./...` — should compile cleanly.
2. `go test ./...` — existing tests should pass.
3. To reproduce the index issue: temporarily set `now.Weekday()` to 6, hour/min/sec to 23/59/59, and `now.Nanosecond()` to 999999999 in a local test — without the clamp the access panics; with it the last character is returned.

## Audit note

**Reviewed:** `station.go` (only source file), `go.mod`, `Dockerfile`.

**Other findings (not fixed here):**
- `json.NewEncoder(w).Encode(d)` return value is ignored — low impact since the write error would also fail to deliver a response to the client.
- The Dockerfile (`numbers/Dockerfile`) uses an Alpine base image; PR #23 (dependabot) already bumps it to 3.23 — no action needed from this audit.
- Dependencies look current (`go 1.24.0`, chi v5.2.5, gutil pinned to a recent commit).

**No `audit/` PR conflicting with this area existed before this one** (existing `audit/multistage-dockerfile` and `audit/upgrade-alpine-3.22` branches have no open PRs).
