### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,12 +22,18 @@ import (
 
 // main wires dependencies and blocks until SIGINT/SIGTERM.
 func main() {
+	os.Exit(run())
+}
+
+// run executes the program, returning the process exit code so that
+// deferred cleanup runs before os.Exit is called.
+func run() int {
 	log, err := logging.NewLogger("numbers")
 	if err != nil {
 		fallback, ferr := zap.NewProduction()
 		if ferr != nil {
 			fmt.Fprintf(os.Stderr, "logger init: %v / %v\n", err, ferr)
-			os.Exit(1)
+			return 1
 		}
 		fallback.Warn("falling back to zap.NewProduction logger", zap.Error(err))
 		log = fallback.Sugar()
@@ -42,7 +48,7 @@ func main() {
 	exporter, err := otelprom.New(otelprom.WithRegisterer(registry))
 	if err != nil {
 		log.Errorw("otel prometheus exporter", zap.Error(err))
-		os.Exit(1)
+		return 1
 	}
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
 	otel.SetMeterProvider(mp)
@@ -90,5 +96,7 @@ func main() {
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Errorw("http shutdown", zap.Error(err))
+		return 1
 	}
+	return 0
 }


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added stricter linters. This PR fixes the findings so the lint check passes.

## Changes
- gocritic (exitAfterDefer): extract `run()` returning an exit code so deferred logger Sync and meter-provider shutdown actually run before `os.Exit`. `main()` now just calls `os.Exit(run())`.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` — 0 issues
- `go build ./...` — passes
- `go test ./...` — passes

Generated with [Claude Code](https://claude.com/claude-code)